### PR TITLE
Adds @travis-ci testing to the Sphinx docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install: "pip install -q -r requirements.txt --use-mirrors"
+# command to run tests
+script: sphinx-build -nW -b html -d _build/doctrees . _build/html
+# Flags used here, not in `make html`:
+#  -n   Run in nit-picky mode. Currently, this generates warnings for all missing references.
+#  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.


### PR DESCRIPTION
It is important to note that this will fail on _any_ warnings, and will fail on the first found. Subsequent errors may exist, and the `make html` command should be run locally to produce all warnings and errors.

I mocked up an example here: https://travis-ci.org/miketheman/sphinx-rtd-travis/builds

Considering RTD is much more "relaxed" on warnings, I thought it prudent to error out on stuff that might end up looking ugly, be wrong, etc - as well as encourage good behavior - i.e. building and testing before pushing code. I will spell out the process in the project's README.md
