### PR TITLE
Add another link to a Uni programme in See Also

### DIFF
--- a/seealso.rst
+++ b/seealso.rst
@@ -5,14 +5,15 @@ A list of System Administration or Ops related classes or degree granting
 programs. It would be well worth our time to compare their syllabi, course
 outcomes, exercises etc.
 
-http://www.hioa.no/Studier/TKD/Master/Network-and-System-Administration/
-http://www.hioa.no/Programmes/Summer/Network-and-systems-administration
-http://www.cs.stevens.edu/~jschauma/615/
-http://goo.gl/4ygBn
-http://www.cs.fsu.edu/current/grad/cnsa_ms.php
-http://www.rit.edu/programs/applied-networking-and-system-administration-bs
-http://www.mtu.edu/technology/undergraduate/cnsa/
-http://www.wit.edu/computer-science/programs/BSCN.html
+- http://www.hioa.no/Studier/TKD/Master/Network-and-System-Administration/
+- http://www.hioa.no/Programmes/Summer/Network-and-systems-administration
+- http://www.cs.stevens.edu/~jschauma/615/
+- http://goo.gl/4ygBn
+- http://www.cs.fsu.edu/current/grad/cnsa_ms.php
+- http://www.rit.edu/programs/applied-networking-and-system-administration-bs
+- http://www.mtu.edu/technology/undergraduate/cnsa/
+- http://www.wit.edu/computer-science/programs/BSCN.html
+- http://www.his.se/english/education/island/net--og-kerfisstjornun/
 
 In addition, Usenix SAGE (now LISA) used to have a sage-edu@usenix.org mailing
 list, but I don’t know if that is still active.  LOPSA has


### PR DESCRIPTION
This commit adds the Network and Systems Administrator programme at the
Swedish University of Skovde at the See Also page. It also converts the
format to links instead of a blob of text.
