### PR TITLE
Removes double spaces after end of sentence

### DIFF
--- a/boot_process_101.rst
+++ b/boot_process_101.rst
@@ -165,7 +165,7 @@ MBR to load an another program from elsewhere on the drive into memory. The new
 program is then executed and continues the boot process.
 
 If you're familiar with Windows, you may have seen drives labelled as "C:" and
-"D:" - these represent different logical "partitions" on the drive.  These
+"D:" - these represent different logical "partitions" on the drive. These
 represent partitions defined in that 64-byte partition table.
 
 

--- a/introduction.rst
+++ b/introduction.rst
@@ -15,7 +15,7 @@ Usenix defines this role as:
    level; ability to edit files, use basic utilities and commands, find users’
    home directories, navigate through the file system, install software on
    workstations, and use I/O redirection; some understanding of how user
-   authentication happens in a directory service context.  Ability to
+   authentication happens in a directory service context. Ability to
    identify/locate shared resources and perform simple tasks (e.g., manipulate
    jobs in a print queue, figure out why a network file system isn’t
    available).

--- a/labs.rst
+++ b/labs.rst
@@ -88,7 +88,7 @@ Database 301
 Galera cluster
 --------------
 
-* Introduction to variables and their meaning.  Tuning MySQL configuration (use
+* Introduction to variables and their meaning. Tuning MySQL configuration (use
   mysqltuner.pl as a launch point?), pros and cons of various options.
 * Introducing EXPLAIN and how to analyse and improve queries and schema.
 * Backup options, mysqldump, LVM Snapshotting, Xtrabackup.

--- a/monitoring_201.rst
+++ b/monitoring_201.rst
@@ -60,7 +60,7 @@ The disk format to store all this data is rather simple. Every file has a
 short header with the basic information about the aggregation function used,
 the maximum retention period available, the *x-files-factor* and the number of
 archives it contains. These are stored as 2 *longs*, a *float* and another
-*long* thus requiring 16 bytes of storage.  After that the archives are
+*long* thus requiring 16 bytes of storage. After that the archives are
 appended to the file with their *(timestamp, value)* pairs stored as a *long*
 and a *double* value consuming 12 bytes per pair.
 
@@ -254,7 +254,7 @@ The general configuration file contains settings like network configuration
 AMQP), cache sizes and maximum updates per second in its ``[cache]`` section.
 These settings are very useful when tuning the carbon daemon for the hardware
 it's running on, but to get started the default settings from the example
-config files will suffice.  The storage schemas configuration file contains
+config files will suffice. The storage schemas configuration file contains
 information about which metrics paths are using which retention archives and
 aggregation methods. A basic entry looks like this:
 

--- a/seealso.rst
+++ b/seealso.rst
@@ -16,7 +16,7 @@ outcomes, exercises etc.
 - http://www.his.se/english/education/island/net--og-kerfisstjornun/
 
 In addition, Usenix SAGE (now LISA) used to have a sage-edu@usenix.org mailing
-list, but I don’t know if that is still active.  LOPSA has
+list, but I don’t know if that is still active. LOPSA has
 https://lists.lopsa.org/cgi-bin/mailman/listinfo/educators
 
 http://www.verticalsysadmin.com/Report_on_programs_in_System_Administration__25-June-2012.pdf

--- a/shells_101.rst
+++ b/shells_101.rst
@@ -34,9 +34,9 @@ the command line.
 Environment variables
 ---------------------
 Environment variables are used to define values for often-used attributes of a
-user's shell.  In total, these variables define the user's environment.  Some
+user's shell. In total, these variables define the user's environment. Some
 environment variables provide a simple value describing some basic attribute,
-such the user's current directory (``$PWD``).  Others define the behavior of a
+such the user's current directory (``$PWD``). Others define the behavior of a
 command, such as whether or not the ``history`` command should log repeated
 commands individually or log the repeated command once (``$HISTCONTROL``).
 


### PR DESCRIPTION
This is a typesetting issue, long gone with the death of the typewriter.

It may be easier to read in a monospaced text editor, but mucks with rendered HTML, and is simply not necessary.
