### PR TITLE
Reference to "credits" file is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ wonderful things, please follow this process:
   feedback. Community review is also encouraged.
 
 If you submit a pull request and would like to have your name associated with
-the project, add it to the [`contributions.rst`](meta/contributions.rst) file!
+the project, add it to the `meta/contributions.rst` file!
 
 Some cool things:
 


### PR DESCRIPTION
The README file references a "credits.rst" which was moved and renamed. I've updated the reference.

I tried to insert an actual link, but apparently GitHub doesn't support relative links in this way (per https://github.com/github/markup/issues/101).

Thanks,
Adam
