### PR TITLE
Add ansible, some notes about confg management section in progress

### DIFF
--- a/config_management.rst
+++ b/config_management.rst
@@ -1,6 +1,9 @@
 Configuration Management 101
 ****************************
 
+The Case for Configuration Management
+=====================================
+
 Idempotency
 ===========
 
@@ -9,6 +12,8 @@ Convergent and Congruent systems
 
 Direct and Indirect systems: ansible, capistrano
 ================================================
+
+(mpdehaan: Are we talking about deployment here?  Then let's start a deployment section.  What does direct/indirect mean? How about not addressing tools in 101 and talking about concepts, so as to make a better tools section? Ansible operates in both push and pull topologies, so I'm guessing that is not what is meant about direct/indirect?)
 
 Chef
 ====
@@ -21,6 +26,15 @@ today like Perl was for a lot of us in the 90's)
 
 Configuration Management 201
 ****************************
+
+Ansible
+=======
+
+`Ansible <http://ansible.cc>`_ is a configuration management, deployment, and remote execution tool that uses SSH to address remote machines (though it offers other connection types, including 0mq).  It requires no server software nor any remote programs, and works by shipping small modules to remote machines that provide idempotent resource management.  While implemented in Python, Ansible uses a basic YAML data language to describe how to orchestrate operations on remote systems.  
+
+Ansible can be extended by writing modules in any language you want, though there is some accelerated module writing ability that makes it easier to do them in Python.
+
+To prevent documentation drift, see `Ansible documentation site <http://ansible.cc/docs>`_.
 
 Puppet
 ======


### PR DESCRIPTION
Hi guys, good start, I like this idea.

I would suggest we keep the 101 section of CM perhaps tool agnostic and conceptual.

I also am not sure about the direct/indirect part, what that was intended to mean, and think maybe deployment should be a seperate section.

As many (ALL) of these tools change frequently and have massive docs, I think to some extent we could just talk about conceptual things and link to the main documentation.

We should probably try to avoid marketable statements about "is the best" and so on, and mainly highlight what is out there so people can figure it out.   (Similar to the matrix on the Wikipedia configuration management page).
