### PR TITLE
Add Cron Output Section

### DIFF
--- a/cron_101.rst
+++ b/cron_101.rst
@@ -247,8 +247,8 @@ An email will be sent containing the output from STDOUT/STDERR every time the co
 Unfortunately, the email gives no indication of the return status of the process (success or failure) and often leads to a cluttered inbox. 
 
 .. note:: If your crontab is misconfigured you won't receive an email at all. 
-Finding such failures (the lack of an email in your inbox) is hard to detect. 
-To save time and avoid these *silent failures*, it is better to use a service that will notify you only on cron failures. [#]_
+  Finding such failures (the lack of an email in your inbox) is hard to detect. 
+  To save time and avoid these *silent failures*, it is better to use a service that will notify you only on cron failures. [#]_
 
 --------
 


### PR DESCRIPTION
Many of us have been bit by cron's silent failures, only to find out that our jobs haven't been running for hours, or worse, days. Cron's output, though great in theory, isn't as reliable or as helpful as it could be. Our team has made sure to include this common "pitfall" in our teaching sessions and thought it would serve nicely here as well. Feedback appreciated!
