### PR TITLE
Corrected blatant falsehood in monitoring 101

### DIFF
--- a/monitoring_101.rst
+++ b/monitoring_101.rst
@@ -40,7 +40,6 @@ It has basic scheduling for on-call periods, and supports time periods in which 
 
 Since Nagios is so configurable, it can often be difficult to configure for the uninitiated.
 It can use many files for configuration, and a single syntax error will prevent the system from starting.
-Additionally, the open-source version does not natively support adding and removing hosts dynamically; the configuration needs to be modified, and the server restarted to add or remove a host.
 
 
 Graphite


### PR DESCRIPTION
 Anyone who has run `service nagios reload` can confirm that hosts can be added to Nagios
without a restart. Currently do not have access to a Nagios system to test, but I am certain it works.
