### PR TITLE
add netscaler content

### DIFF
--- a/loadbalancing_101.rst
+++ b/loadbalancing_101.rst
@@ -148,6 +148,19 @@ product supports SSL termination and offloading, with additional licensing.
 Netscaler
 ---------
 
+Citrix Netscaler is a proprietary load balancer that runs as a userspace process
+on a FreeBSD system. It is available as a hardware device or a virtual
+appliance.
+
+The system can be managed through a Cisco-style CLI, a web interface (older
+versions depend on Java in the browser), or the UNIX shell.
+
+Netscaler relies on patented traffic handling techniques to send layer 7
+requests from multiple clients over a single "warm" TCP connection. These
+techniques are known as "Request Switching" and "Connection Multiplexing".
+
+Netscaler supports SSL termination and offloading.
+
 Multi-dc
 ========
 


### PR DESCRIPTION
Please consider this pull request with content about Citrix Netscaler.

This content is based on the fine book _Troubleshooting Netscaler_ by Raghu Varma Tirumalaraju. I did not copy any content directly, but we might still consider crediting the original source or providing a link. I didn't see citations elsewhere in the repo, so I was not sure how to handle this.

My totally unqualified opinion is that it's OK (not risky to the opsschool project, and not harmful to Mr. Tirumalaraju) to include the content as is. But I think it would be good to provide a link out of courtesy.
