### PR TITLE
Add vi examples to shells 101

### DIFF
--- a/shells_101.rst
+++ b/shells_101.rst
@@ -42,7 +42,15 @@ The following commands are very common while using the ``emacs`` mode.
 - ``Ctrl-u``: Delete from the cursor backward
 - ``Ctrl-r``: Search the command history
 
-.. todo:: Add vi examples. I haven't used that mode in years and will need to look up the mirror version of the above commands.
+The following commands are very common while using the ``vi`` mode.
+
+- ``h``: Move backward by one character
+- ``l``: Move forward by one character
+- ``0``: Move to the beginning of the line
+- ``$``: Move to the end of the line
+- ``d$``: Delete from the cursor to the end of the line
+- ``d0``: Delete from the cursor the beginning of the line
+- ``:history s``: Search the command history
 
 Setting the Mode
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The existing shells_101 page has a Todo box waiting for the addition of vi examples. Add the vi examples mirroring the emacs examples to the existing page. Then, remove the Todo box for the vi examples section.