### PR TITLE
Update networking_101.rst

### DIFF
--- a/networking_101.rst
+++ b/networking_101.rst
@@ -247,10 +247,18 @@ which aims to address the IPv4 address exhaustion problem.
 
 Probably the most obvious difference of IPv6 to IPv4 is the representation of addresses.
 Unlike IPV4, IPv6 uses a hexadecimal format to represent a 128-bit address. The format is
-grouped into 8 hextets separated by a colon.
+grouped into 8 groups of four hexadecimal digits separated by a colon.
 For example: 
 
-    3341:1112:AAAA:0001:4321:5876:CBAD:1234
+    2001:0DB8:0000:CBAD:4321:0000:0000:1234
+
+Leading zeroes may be left off of a group in the address. Whole groups of zeros may be
+left out entirely, but only once. Generally, the longest run of zeros is dropped, but
+any run may be. Using these rules, the above address can also be represented in either
+of these ways:
+
+    2001:DB8::CBAD:4321:0000:0000:1234
+    2001:DB8:0000:CBAD:4321::1234
 
 TCP vs UDP
 ==========


### PR DESCRIPTION
Replaced the uncommon word "hextets" with an expansion.

Changed the example IPv6 address to be in the block reserved in RFC 3849 for documentation.

Added a short explanation of zero-replacing in IPv6 addresses.