### PR TITLE
Fix spacing between Tyler and Francesca examples

### DIFF
--- a/sysadmin_101.rst
+++ b/sysadmin_101.rst
@@ -187,7 +187,7 @@ These backends can be big, and have many considerations behind their design.
   his code will run on. He works closely with his Operations engineers to make sure his
   code is performant and on capacity planning.
 
-  .. _whats-developer-francesca:
+.. _whats-developer-francesca:
 
 * **Francesca is one of five students working on the website for her school's
   internationally famous hackathon.** She and her friends run a Tornado web server


### PR DESCRIPTION
Originally there was no spacing between the Tyler and Francesca examples in Sysadmin 101:
<img width="285" alt="old-spacing" src="https://user-images.githubusercontent.com/90757/111723874-7b5e2d80-8821-11eb-8d78-30037e85e9f9.png">

Fixed the indent in the code so the spacing is now consistent with the other examples:
<img width="350" alt="new-spacing" src="https://user-images.githubusercontent.com/90757/111723935-9761cf00-8821-11eb-8974-729e897c150e.png">
